### PR TITLE
Snap option when creating tile can be check and value empty. If that …

### DIFF
--- a/WPFEditor/Controls/SpriteEditor.xaml.cs
+++ b/WPFEditor/Controls/SpriteEditor.xaml.cs
@@ -48,7 +48,12 @@ namespace MegaMan.Editor.Controls
             if (snapSheet.IsChecked == true)
             {
                 var viewModel = DataContext as SpriteEditorViewModel;
-                var spacing = sheetHighlight.Width + (snapGap.Value.Value * viewModel.SheetZoom);
+                int snapGapValue = 0;
+
+                if (snapGap.Value != null) snapGapValue = snapGap.Value.Value;
+                
+                var spacing = sheetHighlight.Width + (snapGapValue * viewModel.SheetZoom);
+
                 pos = new Point(Math.Floor(pos.X / spacing) * spacing, Math.Floor(pos.Y / spacing) * spacing);
             }
 


### PR DESCRIPTION
…happens, null value would throw an exception. Now 0 is used by default.
